### PR TITLE
Replace StrictVersion by LooseVersion

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -15,10 +15,10 @@ def sanity_check_dependencies():
     import requests
     import six
 
-    if distutils.version.StrictVersion(numpy.__version__) < distutils.version.StrictVersion('1.10.4'):
+    if distutils.version.LooseVersion(numpy.__version__) < distutils.version.LooseVersion('1.10.4'):
         logger.warn("You have 'numpy' version %s installed, but 'gym' requires at least 1.10.4. HINT: upgrade via 'pip install -U numpy'.", numpy.__version__)
 
-    if distutils.version.StrictVersion(requests.__version__) < distutils.version.StrictVersion('2.0'):
+    if distutils.version.LooseVersion(requests.__version__) < distutils.version.LooseVersion('2.0'):
         logger.warn("You have 'requests' version %s installed, but 'gym' requires at least 2.0. HINT: upgrade via 'pip install -U requests'.", requests.__version__)
 
 # We automatically configure a logger with a simple stderr handler. If

--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -290,7 +290,7 @@ class ImageEncoder(object):
         if frame.dtype != np.uint8:
             raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
 
-        if distutils.version.StrictVersion(np.__version__) >= distutils.version.StrictVersion('1.9.0'):
+        if distutils.version.LooseVersion(np.__version__) >= distutils.version.LooseVersion('1.9.0'):
             self.proc.stdin.write(frame.tobytes())
         else:
             self.proc.stdin.write(frame.tostring())


### PR DESCRIPTION
Replaces the parsing function for the version comparison, to allow non standard versions. Remains unchanged for standard versions. http://epydoc.sourceforge.net/stdlib/distutils.version.LooseVersion-class.html
